### PR TITLE
Don't require array for render_shortcode

### DIFF
--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -396,7 +396,7 @@ class WP_Team_List {
 	 * @param array $atts Shortcode attributes.
 	 * @return string The rendered team list.
 	 */
-	public function render_shortcode( array $atts ) {
+	public function render_shortcode( $atts ) {
 		$args = shortcode_atts( array(
 			'role'                => 'Administrator',
 			'orderby'             => 'post_count',

--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -393,7 +393,7 @@ class WP_Team_List {
 	/**
 	 *  Shortcode callback to render the team list.
 	 *
-	 * @param array $atts Shortcode attributes.
+	 * @param array|string $atts Shortcode attributes.
 	 * @return string The rendered team list.
 	 */
 	public function render_shortcode( $atts ) {


### PR DESCRIPTION
Expecting an `array` here gives me the following error:

`Catchable fatal error: Argument 1 passed to WP_Team_List::render_shortcode() must be of the type array, string given in /{obfuscated}/plugins/wp-team-list/includes/class-wp-team-list.php on line 399`

Fixes #22