### PR TITLE
Deprecate old shortcode

### DIFF
--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -479,7 +479,6 @@ class WP_Team_List {
 			),
 		);
 
-		shortcode_ui_register_for_shortcode( 'rplus_team_list', $shortcode_ui_args );
 		shortcode_ui_register_for_shortcode( 'wp_team_list', $shortcode_ui_args );
 	}
 

--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -413,8 +413,7 @@ class WP_Team_List {
 				sprintf(
 					__( 'The %1$s shortcode has been replaced with %2$s.', 'wp-team-list' ),
 					'<code>[rplus_team_list]</code>',
-					'<code>[wp_team_list]</code>',
-				'wp-config.php'
+					'<code>[wp_team_list]</code>'
 				)
 			);
 		}

--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -398,12 +398,27 @@ class WP_Team_List {
 	}
 
 	/**
-	 *  Shortcode callback to render the team list.
+	 * Shortcode callback to render the team list.
 	 *
-	 * @param array|string $atts Shortcode attributes.
+	 * @param array|string $atts    Shortcode attributes.
+	 * @param string       $content Shortcode inner content.
+	 * @param string       $tag     Shortcode name.
 	 * @return string The rendered team list.
 	 */
-	public function render_shortcode( $atts ) {
+	public function render_shortcode( $atts, $content = null, $tag = '' ) {
+		if ( 'rplus_team_list' === $tag ) {
+			_deprecated_argument(
+				'do_shortcode_tag()',
+				'2.0.0',
+				sprintf(
+					__( 'The %1$s shortcode has been replaced with %2$s.', 'wp-team-list' ),
+					'<code>[rplus_team_list]</code>',
+					'<code>[wp_team_list]</code>',
+				'wp-config.php'
+				)
+			);
+		}
+
 		$args = shortcode_atts( array(
 			'role'                => 'Administrator',
 			'orderby'             => 'post_count',


### PR DESCRIPTION
- Adds deprecation notice
   - `Notice: do_shortcode_tag() was called with an argument that is deprecated since version 2.0.0! The [rplus_team_list] shortcode has been replaced with [wp_team_list]. in /srv/www/wp-develop/svn/src/wp-includes/functions.php on line 4021`
- Removes shortcode UI.

Fixes #23.