### PR TITLE
Don't use the display names for CSS class names

### DIFF
--- a/includes/class-wp-team-list.php
+++ b/includes/class-wp-team-list.php
@@ -482,21 +482,34 @@ class WP_Team_List {
 	}
 
 	/**
-	 * Get a specific users' role.
+	 * Retrieve data of user's first role.
 	 *
-	 * @param \WP_User $user User object.
-	 * @return string Translated role name.
+	 * @param WP_User $user  User object.
+	 * @param string  $field Optional. Field to retrieve. Accepts 'name' and
+	 *                       'display_name'. Default: 'display_name'.
+	 * @return string|false Field value on success, false otherwise.
 	 */
-	public function get_user_role( WP_User $user ) {
-		$role = translate_with_gettext_context( $GLOBALS['wp_roles']->roles[ $user->roles[0] ]['name'], 'User role', 'wp-team-list' );
+	public function get_user_role( WP_User $user, $field = 'display_name' ) {
+		$role = current( $user->roles );
 
-		/**
-		 * Filter the user role displayed in the team list.
-		 *
-		 * @param string  $role Role name.
-		 * @param WP_User $user User object.
-		 */
-		return apply_filters( 'wp_team_list_user_role', $role, $user );
+		switch ( $field ) {
+			case 'display_name' :
+				$role_names = $GLOBALS['wp_roles']->get_names();
+				$role_name  = translate_with_gettext_context( $role_names[ $role ], 'User role', 'wp-team-list' );
+
+				/**
+				 * Filter the display name of user's role displayed in the team list.
+				 *
+				 * @param string  $role_name Role name.
+				 * @param WP_User $user      User object.
+				 */
+				return apply_filters( 'wp_team_list_user_role', $role_name, $user );
+
+			case 'name' :
+				return $role;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/rplus-wp-team-list.php
+++ b/includes/rplus-wp-team-list.php
@@ -12,9 +12,10 @@
 
 $role_display_name = wp_team_list()->get_user_role( $user, 'display_name' );
 $role              = wp_team_list()->get_user_role( $user, 'name' );
+$role_class        = sanitize_html_class( 'role-' . $role );
 $description       = get_user_meta( $user->ID, 'description', true );
 ?>
-<div class="wp-team-member wp-team-list-item author-<?php echo esc_attr( $user->ID ); ?> <?php echo sanitize_html_class( 'role-' . $role ); ?>">
+<div class="wp-team-member wp-team-list-item author-<?php echo esc_attr( $user->ID ); ?> <?php echo esc_attr( $role_class ); ?>">
 	<figure class="wp-team-member-avatar author-image">
 		<?php echo wp_team_list()->get_avatar( $user ); ?>
 	</figure>

--- a/includes/rplus-wp-team-list.php
+++ b/includes/rplus-wp-team-list.php
@@ -10,10 +10,11 @@
  * @package WP_Team_List
  */
 
-$role        = wp_team_list()->get_user_role( $user );
-$description = get_user_meta( $user->ID, 'description', true );
+$role_display_name = wp_team_list()->get_user_role( $user, 'display_name' );
+$role              = wp_team_list()->get_user_role( $user, 'name' );
+$description       = get_user_meta( $user->ID, 'description', true );
 ?>
-<div class="wp-team-member wp-team-list-item author-<?php echo esc_attr( $user->ID ); ?> role-<?php echo esc_attr( $role ); ?>">
+<div class="wp-team-member wp-team-list-item author-<?php echo esc_attr( $user->ID ); ?> <?php echo sanitize_html_class( 'role-' . $role ); ?>">
 	<figure class="wp-team-member-avatar author-image">
 		<?php echo wp_team_list()->get_avatar( $user ); ?>
 	</figure>
@@ -21,8 +22,8 @@ $description = get_user_meta( $user->ID, 'description', true );
 	<h2 class="wp-team-member-name"><?php echo esc_html( $user->data->display_name ); ?></h2>
 
 	<?php
-	if ( '' !== $role ) {
-		printf( '<p class="wp-team-member-role">%s</p>', esc_html( $role ) );
+	if ( '' !== $role_display_name ) {
+		printf( '<p class="wp-team-member-role">%s</p>', esc_html( $role_display_name ) );
 	}
 
 	if ( '' !== $description ) {


### PR DESCRIPTION
Fixes #38.

This adds a 'field' parameter to the existing method instead of adding a new method (#39).